### PR TITLE
Genitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Please cite this book if using this dataset.
 
 # Changelog
 
+* 2021-05-15 v2.8
+  * Removed Case=Gen. This feature is not documented for English and not used in the other English UD treebank.
 * 2019-10-17 v1.0
   * First release in UD
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Please cite this book if using this dataset.
 # Changelog
 
 * 2021-05-15 v2.8
-  * Removed Case=Gen. This feature is not documented for English and not used in the other English UD treebank.
+  * Removed Case=Gen. This feature is not documented for English and not used in the other English UD treebanks.
 * 2019-10-17 v1.0
   * First release in UD
 

--- a/en_pronouns-ud-test.conllu
+++ b/en_pronouns-ud-test.conllu
@@ -5,7 +5,7 @@
 # comment = copular subject
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 2
@@ -14,7 +14,7 @@
 # comment = copular subject
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 3
@@ -23,7 +23,7 @@
 # comment = copular subject
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 4
@@ -32,7 +32,7 @@
 # comment = copular subject
 1	It	it	PRON	PERS-SG	Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 5
@@ -41,7 +41,7 @@
 # comment = copular subject
 1	It	it	PRON	PERS-SG	Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 6
@@ -50,7 +50,7 @@
 # comment = abbreviated copular subject
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 7
@@ -59,7 +59,7 @@
 # comment = abbreviated copular subject
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 8
@@ -68,7 +68,7 @@
 # comment = abbreviated copular subject
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 9
@@ -77,7 +77,7 @@
 # comment = abbreviated copular subject
 1	It	it	PRON	PERS-SG	Number=Sing|Person=1|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 10
@@ -86,7 +86,7 @@
 # comment = abbreviated copular subject
 1	It	it	PRON	PERS-SG	Number=Sing|Person=2|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 11
@@ -96,7 +96,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	all	all	PRON	TOT-SG	Case=Nom	4	det:predet	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	ExclMark	_	4	punct	_	_
 
 # sent_id = 12
@@ -106,7 +106,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	all	all	PRON	TOT-SG	Case=Nom	4	det:predet	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	ExclMark	_	4	punct	_	_
 
 # sent_id = 13
@@ -116,7 +116,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	all	all	PRON	TOT-SG	Case=Nom	4	det:predet	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	ExclMark	_	4	punct	_	_
 
 # sent_id = 14
@@ -126,7 +126,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=1|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	all	all	PRON	TOT-SG	Case=Nom	4	det:predet	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	ExclMark	_	4	punct	_	_
 
 # sent_id = 15
@@ -136,7 +136,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=2|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	all	all	PRON	TOT-SG	Case=Nom	4	det:predet	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	ExclMark	_	4	punct	_	_
 
 # sent_id = 16
@@ -146,7 +146,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	mostly	most	ADV	RB	_	4	advmod	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 17
@@ -156,7 +156,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	mostly	most	ADV	RB	_	4	advmod	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 18
@@ -166,7 +166,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	mostly	most	ADV	RB	_	4	advmod	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 19
@@ -176,7 +176,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=1|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	mostly	most	ADV	RB	_	4	advmod	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 20
@@ -186,7 +186,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=2|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	mostly	most	ADV	RB	_	4	advmod	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 21
@@ -195,7 +195,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	not	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	ExclMark	_	4	punct	_	_
 
 # sent_id = 22
@@ -204,7 +204,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	not	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	ExclMark	_	4	punct	_	_
 
 # sent_id = 23
@@ -213,7 +213,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	not	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	ExclMark	_	4	punct	_	_
 
 # sent_id = 24
@@ -222,7 +222,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=1|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	not	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	ExclMark	_	4	punct	_	_
 
 # sent_id = 25
@@ -231,7 +231,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=2|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	not	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	ExclMark	_	4	punct	_	_
 
 # sent_id = 26
@@ -241,7 +241,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	n't	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 27
@@ -251,7 +251,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	n't	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 28
@@ -261,7 +261,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	n't	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 29
@@ -271,7 +271,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	n't	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 30
@@ -281,7 +281,7 @@
 1	It	it	PRON	PERS-SG	Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	n't	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 31
@@ -291,7 +291,7 @@
 1	it	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	ai	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	nt	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
 
 # sent_id = 32
 # text = it aint his
@@ -300,7 +300,7 @@
 1	it	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	ai	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	nt	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
 
 # sent_id = 33
 # text = it aint theirs
@@ -309,7 +309,7 @@
 1	it	it	PRON	PERS-SG	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	ai	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	nt	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
 
 # sent_id = 34
 # text = it aint mine
@@ -318,7 +318,7 @@
 1	it	it	PRON	PERS-SG	Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 2	ai	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	nt	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	_
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	_
 
 # sent_id = 35
 # text = it aint yours
@@ -327,7 +327,7 @@
 1	it	it	PRON	PERS-SG	Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
 2	ai	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	nt	not	PART	PART	Polarity=Neg	4	advmod	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	_
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	_
 
 # sent_id = 36
 # text = The car is hers.
@@ -336,7 +336,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	_
 3	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 37
@@ -346,7 +346,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	_
 3	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 38
@@ -356,7 +356,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	_
 3	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 39
@@ -366,7 +366,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	_
 3	is	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 40
@@ -376,7 +376,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	_
 3	is	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 41
@@ -386,7 +386,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 42
@@ -396,7 +396,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 43
@@ -406,7 +406,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 44
@@ -416,7 +416,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 45
@@ -426,7 +426,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	4	punct	_	_
 
 # sent_id = 46
@@ -437,7 +437,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	all	all	PRON	TOT-SG	Case=Nom	5	nmod	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	ExclMark	_	5	punct	_	_
 
 # sent_id = 47
@@ -448,7 +448,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	all	all	PRON	TOT-SG	Case=Nom	5	nmod	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	ExclMark	_	5	punct	_	_
 
 # sent_id = 48
@@ -459,7 +459,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	all	all	PRON	TOT-SG	Case=Nom	5	nmod	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	ExclMark	_	5	punct	_	_
 
 # sent_id = 49
@@ -470,7 +470,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	all	all	PRON	TOT-SG	Case=Nom	5	nmod	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	ExclMark	_	5	punct	_	_
 
 # sent_id = 50
@@ -481,7 +481,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	all	all	PRON	TOT-SG	Case=Nom	5	nmod	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	ExclMark	_	5	punct	_	_
 
 # sent_id = 51
@@ -492,7 +492,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	mostly	most	ADV	RB	_	5	advmod	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
 
 # sent_id = 52
@@ -503,7 +503,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	mostly	most	ADV	RB	_	5	advmod	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
 
 # sent_id = 53
@@ -514,7 +514,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	mostly	most	ADV	RB	_	5	advmod	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
 
 # sent_id = 54
@@ -525,7 +525,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	mostly	most	ADV	RB	_	5	advmod	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
 
 # sent_id = 55
@@ -536,7 +536,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	mostly	most	ADV	RB	_	5	advmod	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
 
 # sent_id = 56
@@ -547,7 +547,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	not	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	ExclMark	_	5	punct	_	_
 
 # sent_id = 57
@@ -558,7 +558,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	not	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	ExclMark	_	5	punct	_	_
 
 # sent_id = 58
@@ -569,7 +569,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	not	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	ExclMark	_	5	punct	_	_
 
 # sent_id = 59
@@ -580,7 +580,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	not	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	ExclMark	_	5	punct	_	_
 
 # sent_id = 60
@@ -591,7 +591,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	not	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	ExclMark	_	5	punct	_	_
 
 # sent_id = 61
@@ -602,7 +602,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	n't	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
 
 # sent_id = 62
@@ -613,7 +613,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	n't	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
 
 # sent_id = 63
@@ -624,7 +624,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	n't	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
 
 # sent_id = 64
@@ -635,7 +635,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	is	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	n't	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
 
 # sent_id = 65
@@ -646,7 +646,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	is	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	n't	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
 
 # sent_id = 66
@@ -657,7 +657,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	ai	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	nt	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
 
 # sent_id = 67
 # text = The car aint his
@@ -667,7 +667,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	ai	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	nt	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
 
 # sent_id = 68
 # text = The car aint theirs
@@ -677,7 +677,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	ai	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	nt	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	_
 
 # sent_id = 69
 # text = The car aint mine
@@ -687,7 +687,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	ai	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	nt	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	_
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	_
 
 # sent_id = 70
 # text = The car aint yours
@@ -697,7 +697,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	ai	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	nt	not	PART	PART	Polarity=Neg	5	advmod	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	_
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	_
 
 # sent_id = 71
 # text = Any car of hers sells quickly.
@@ -706,7 +706,7 @@
 1	Any	any	DET	DT	PronType=Ind	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	E	_	4	case	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	sells	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	quickly	quickly	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	5	punct	_	_
@@ -718,7 +718,7 @@
 1	Any	any	DET	DT	PronType=Ind	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	E	_	4	case	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	sells	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	quickly	quickly	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	5	punct	_	_
@@ -730,7 +730,7 @@
 1	Any	any	DET	DT	PronType=Ind	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	E	_	4	case	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	sells	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	quickly	quickly	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	5	punct	_	_
@@ -742,7 +742,7 @@
 1	Any	any	DET	DT	PronType=Ind	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	E	_	4	case	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	sells	sell	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	quickly	quickly	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	5	punct	_	_
@@ -754,7 +754,7 @@
 1	Any	any	DET	DT	PronType=Ind	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	E	_	4	case	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	sells	sell	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	quickly	quickly	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	5	punct	_	_
@@ -765,7 +765,7 @@
 # comment = expositional subject
 1	There	there	PRON	EX	_	2	expl	_	_
 2	is	be	VERB	PRES	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
+3	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 77
@@ -774,7 +774,7 @@
 # comment = expositional subject
 1	There	there	PRON	EX	_	2	expl	_	_
 2	is	be	VERB	PRES	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
+3	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 78
@@ -783,7 +783,7 @@
 # comment = expositional subject
 1	There	there	PRON	EX	_	2	expl	_	_
 2	is	be	VERB	PRES	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
+3	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 79
@@ -792,7 +792,7 @@
 # comment = expositional subject
 1	There	there	PRON	EX	_	2	expl	_	_
 2	is	be	VERB	PRES	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
+3	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 80
@@ -801,7 +801,7 @@
 # comment = expositional subject
 1	There	there	PRON	EX	_	2	expl	_	_
 2	is	be	VERB	PRES	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
+3	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 81
@@ -812,7 +812,7 @@
 2	car	car	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	is	be	VERB	PRES	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	E	_	5	case	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 82
@@ -823,7 +823,7 @@
 2	car	car	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	is	be	VERB	PRES	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	E	_	5	case	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 83
@@ -834,7 +834,7 @@
 2	car	car	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	is	be	VERB	PRES	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	E	_	5	case	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 84
@@ -845,7 +845,7 @@
 2	car	car	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	is	be	VERB	PRES	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	E	_	5	case	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 85
@@ -856,14 +856,14 @@
 2	car	car	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	is	be	VERB	PRES	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	E	_	5	case	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 86
 # text = Hers is nice.
 # previous = What do you think of Alex's car?
 # comment = copular subject with adjective
-1	Hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Plur|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	nice	quick	ADJ	A	_	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -872,7 +872,7 @@
 # text = His is nice.
 # previous = What do you think of Alex's car?
 # comment = copular subject with adjective
-1	His	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	His	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Plur|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	nice	quick	ADJ	A	_	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -881,7 +881,7 @@
 # text = Theirs is nice.
 # previous = What do you think of Alex's car?
 # comment = copular subject with adjective
-1	Theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Plur|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	nice	quick	ADJ	A	_	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -890,7 +890,7 @@
 # text = Mine is nice.
 # previous = What do you think of your car?
 # comment = copular subject with adjective
-1	Mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Plur|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	nice	quick	ADJ	A	_	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -899,7 +899,7 @@
 # text = Yours is nice.
 # previous = What do you think of my car?
 # comment = copular subject with adjective
-1	Yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Plur|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	nice	quick	ADJ	A	_	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -908,7 +908,7 @@
 # text = Hers drove responsively.
 # previous = How did Alex's car drive?
 # comment = subject to irregular intransitive verb
-1	Hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	drove	drive	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	responsively	responsive	ADV	RB	_	2	advmod	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
@@ -917,7 +917,7 @@
 # text = His drove responsively.
 # previous = How did Alex's car drive?
 # comment = subject to irregular intransitive verb
-1	His	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	His	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	drove	drive	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	responsively	responsive	ADV	RB	_	2	advmod	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
@@ -926,7 +926,7 @@
 # text = Theirs drove responsively.
 # previous = How did Alex's car drive?
 # comment = subject to irregular intransitive verb
-1	Theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	drove	drive	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	responsively	responsive	ADV	RB	_	2	advmod	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
@@ -935,7 +935,7 @@
 # text = Mine drove responsively.
 # previous = How did your car drive?
 # comment = subject to irregular intransitive verb
-1	Mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	drove	drive	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	_
 3	responsively	responsive	ADV	RB	_	2	advmod	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
@@ -944,7 +944,7 @@
 # text = Yours drove responsively.
 # previous = How did my car drive?
 # comment = subject to irregular intransitive verb
-1	Yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	drove	drive	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	_
 3	responsively	responsive	ADV	RB	_	2	advmod	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
@@ -953,7 +953,7 @@
 # text = Hers accelerated.
 # comment = subject to regular intransitive verb
 # previous = What did Alex's car do?
-1	Hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	accelerated	accelerate	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -961,7 +961,7 @@
 # text = His accelerated.
 # comment = subject to regular intransitive verb
 # previous = What did Alex's car do?
-1	His	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	His	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	accelerated	accelerate	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -969,7 +969,7 @@
 # text = Theirs accelerated.
 # comment = subject to regular intransitive verb
 # previous = What did Alex's car do?
-1	Theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	accelerated	accelerate	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -977,7 +977,7 @@
 # text = Mine accelerated.
 # comment = subject to regular intransitive verb
 # previous = What did your car do?
-1	Mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	accelerated	accelerate	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -985,7 +985,7 @@
 # text = Yours accelerated.
 # comment = subject to regular intransitive verb
 # previous = What did my car do?
-1	Yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	accelerated	accelerate	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -993,7 +993,7 @@
 # text = Hers hit bumps.
 # previous = What did Alex's car hit?
 # comment = subject to regular transitive verb
-1	Hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	hit	hit	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	bumps	bump	NOUN	NNS	Number=Plur	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
@@ -1002,7 +1002,7 @@
 # text = His hit bumps.
 # previous = What did Alex's car hit?
 # comment = subject to regular transitive verb
-1	His	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	His	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	hit	hit	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	bumps	bump	NOUN	NNS	Number=Plur	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
@@ -1011,7 +1011,7 @@
 # text = Theirs hit bumps.
 # previous = What did Alex's car hit?
 # comment = subject to regular transitive verb
-1	Theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	hit	hit	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	bumps	bump	NOUN	NNS	Number=Plur	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
@@ -1020,7 +1020,7 @@
 # text = Mine hit bumps.
 # previous = What did your car hit?
 # comment = subject to regular transitive verb
-1	Mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	hit	hit	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	_
 3	bumps	bump	NOUN	NNS	Number=Plur	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
@@ -1029,7 +1029,7 @@
 # text = Yours hit bumps.
 # previous = What did my car hit?
 # comment = subject to regular transitive verb
-1	Yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	hit	hit	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	_
 3	bumps	bump	NOUN	NNS	Number=Plur	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
@@ -1041,7 +1041,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	gave	give	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
 5	fresh	fresh	ADJ	A	_	6	amod	_	_
 6	paint	paint	NOUN	NN	Number=Sing	3	obj	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1053,7 +1053,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	gave	give	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
 5	fresh	fresh	ADJ	A	_	6	amod	_	_
 6	paint	paint	NOUN	NN	Number=Sing	3	obj	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1065,7 +1065,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	gave	give	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
 5	fresh	fresh	ADJ	A	_	6	amod	_	_
 6	paint	paint	NOUN	NN	Number=Sing	3	obj	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1077,7 +1077,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	gave	give	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	iobj	_	_
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	iobj	_	_
 5	fresh	fresh	ADJ	A	_	6	amod	_	_
 6	paint	paint	NOUN	NN	Number=Sing	3	obj	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1089,7 +1089,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	gave	give	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	iobj	_	_
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	iobj	_	_
 5	fresh	fresh	ADJ	A	_	6	amod	_	_
 6	paint	paint	NOUN	NN	Number=Sing	3	obj	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1100,7 +1100,7 @@
 # comment = direct object to irregular transitive verb (accusative, absolutive) 
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	saw	see	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
+3	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 112
@@ -1109,7 +1109,7 @@
 # comment = direct object to irregular transitive verb (accusative, absolutive) 
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	saw	see	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
+3	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 113
@@ -1118,7 +1118,7 @@
 # comment = direct object to irregular transitive verb (accusative, absolutive) 
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	saw	see	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
+3	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 114
@@ -1127,7 +1127,7 @@
 # comment = direct object to irregular transitive verb (accusative, absolutive) 
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	saw	see	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	_
-3	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
+3	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 115
@@ -1136,7 +1136,7 @@
 # comment = direct object to irregular transitive verb (accusative, absolutive) 
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	saw	see	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	_
-3	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
+3	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 116
@@ -1147,7 +1147,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easy	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1160,7 +1160,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easy	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1173,7 +1173,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easy	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1186,7 +1186,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easy	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1199,7 +1199,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easy	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1212,7 +1212,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1225,7 +1225,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1238,7 +1238,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1251,7 +1251,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1264,7 +1264,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1277,7 +1277,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easy	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1290,7 +1290,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easy	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1303,7 +1303,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easy	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1316,7 +1316,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easy	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1329,7 +1329,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easy	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1342,7 +1342,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1355,7 +1355,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1368,7 +1368,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1381,7 +1381,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1394,7 +1394,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1406,7 +1406,7 @@
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	seeing	see	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 137
@@ -1416,7 +1416,7 @@
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	seeing	see	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 138
@@ -1426,7 +1426,7 @@
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	seeing	see	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 139
@@ -1436,7 +1436,7 @@
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	seeing	see	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 140
@@ -1446,7 +1446,7 @@
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	seeing	see	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 141
@@ -1456,7 +1456,7 @@
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	cleaning	clean	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 142
@@ -1466,7 +1466,7 @@
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	cleaning	clean	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 143
@@ -1476,7 +1476,7 @@
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	cleaning	clean	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 144
@@ -1486,7 +1486,7 @@
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	cleaning	clean	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 145
@@ -1496,7 +1496,7 @@
 1	Dealers	dealer	NOUN	_	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	cleaning	clean	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 146
@@ -1508,7 +1508,7 @@
 3	's	's	PART	POS	_	2	case	_	_
 4	cars	car	NOUN	NNS	Number=Plur	7	nsubj	_	_
 5	and	and	CCONJ	CC	_	6	cc	_	_
-6	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
+6	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
 7	sell	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	quickly	quickly	ADV	RB	_	7	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	Period	_	7	punct	_	_
@@ -1522,7 +1522,7 @@
 3	's	's	PART	POS	_	2	case	_	_
 4	cars	car	NOUN	NNS	Number=Plur	7	nsubj	_	_
 5	and	and	CCONJ	CC	_	6	cc	_	_
-6	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
+6	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
 7	sell	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	quickly	quickly	ADV	RB	_	7	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	Period	_	7	punct	_	_
@@ -1536,7 +1536,7 @@
 3	's	's	PART	POS	_	2	case	_	_
 4	cars	car	NOUN	NNS	Number=Plur	7	nsubj	_	_
 5	and	and	CCONJ	CC	_	6	cc	_	_
-6	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
+6	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
 7	sell	sell	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	quickly	quickly	ADV	RB	_	7	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	Period	_	7	punct	_	_
@@ -1550,7 +1550,7 @@
 3	's	's	PART	POS	_	2	case	_	_
 4	cars	car	NOUN	NNS	Number=Plur	7	nsubj	_	_
 5	and	and	CCONJ	CC	_	6	cc	_	_
-6	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	4	conj	_	_
+6	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	4	conj	_	_
 7	sell	sell	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	quickly	quickly	ADV	RB	_	7	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	Period	_	7	punct	_	_
@@ -1564,7 +1564,7 @@
 3	's	's	PART	POS	_	2	case	_	_
 4	cars	car	NOUN	NNS	Number=Plur	7	nsubj	_	_
 5	and	and	CCONJ	CC	_	6	cc	_	_
-6	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	4	conj	_	_
+6	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	4	conj	_	_
 7	sell	sell	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	quickly	quickly	ADV	RB	_	7	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	Period	_	7	punct	_	_
@@ -1573,7 +1573,7 @@
 # text = Hers and the dealer's sold quickly.
 # previous = Did the dealer's cars and Alex's sell quickly?
 # comment = head part of conjunction
-1	Hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+1	Hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 2	and	and	CCONJ	CC	_	4	cc	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	1	conj	_	SpaceAfter=No
@@ -1586,7 +1586,7 @@
 # text = His and the dealer's sold quickly.
 # previous = Did the dealer's cars and Alex's sell quickly?
 # comment = head part of conjunction
-1	His	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+1	His	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 2	and	and	CCONJ	CC	_	4	cc	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	1	conj	_	SpaceAfter=No
@@ -1599,7 +1599,7 @@
 # text = Theirs and the dealer's sold quickly.
 # previous = Did the dealer's cars and Alex's sell quickly?
 # comment = head part of conjunction
-1	Theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+1	Theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 2	and	and	CCONJ	CC	_	4	cc	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	1	conj	_	SpaceAfter=No
@@ -1612,7 +1612,7 @@
 # text = Mine and the dealer's sold quickly.
 # previous = Did the dealer's cars and your sell quickly?
 # comment = head part of conjunction
-1	Mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+1	Mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 2	and	and	CCONJ	CC	_	4	cc	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	1	conj	_	SpaceAfter=No
@@ -1625,7 +1625,7 @@
 # text = Yours and the dealer's sold quickly.
 # previous = Did the dealer's cars and my sell quickly?
 # comment = head part of conjunction
-1	Yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+1	Yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 2	and	and	CCONJ	CC	_	4	cc	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	1	conj	_	SpaceAfter=No
@@ -1644,7 +1644,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	before	before	ADP	IN	_	7	case	_	_
-7	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 157
@@ -1657,7 +1657,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	before	before	ADP	IN	_	7	case	_	_
-7	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 158
@@ -1670,7 +1670,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	before	before	ADP	IN	_	7	case	_	_
-7	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 159
@@ -1683,7 +1683,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	before	before	ADP	IN	_	7	case	_	_
-7	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 160
@@ -1696,7 +1696,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	before	before	ADP	IN	_	7	case	_	_
-7	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 161
@@ -1704,7 +1704,7 @@
 # previous = Did the dealer clean their car before Alex's car?
 # comment = complement after clause
 1	After	after	ADP	IN	_	2	case	_	_
-2	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
+2	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	6	punct	_	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	dealer	dealer	NOUN	NN	Number=Sing	6	nsubj	_	_
@@ -1718,7 +1718,7 @@
 # previous = Did the dealer clean their car before Alex's car?
 # comment = complement after clause
 1	After	after	ADP	IN	_	2	case	_	_
-2	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
+2	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	6	punct	_	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	dealer	dealer	NOUN	NN	Number=Sing	6	nsubj	_	_
@@ -1732,7 +1732,7 @@
 # previous = Did the dealer clean their car before Alex's car?
 # comment = complement after clause
 1	After	after	ADP	IN	_	2	case	_	_
-2	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
+2	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	6	punct	_	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	dealer	dealer	NOUN	NN	Number=Sing	6	nsubj	_	_
@@ -1746,7 +1746,7 @@
 # previous = Did the dealer clean their car before your car?
 # comment = complement after clause
 1	After	after	ADP	IN	_	2	case	_	_
-2	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
+2	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	6	punct	_	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	dealer	dealer	NOUN	NN	Number=Sing	6	nsubj	_	_
@@ -1760,7 +1760,7 @@
 # previous = Did the dealer clean their car before my car?
 # comment = complement after clause
 1	After	after	ADP	IN	_	2	case	_	_
-2	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
+2	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	6	punct	_	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	dealer	dealer	NOUN	NN	Number=Sing	6	nsubj	_	_
@@ -1773,7 +1773,7 @@
 # text = Hers was cleaned.
 # previous = What happened to Alex's car?
 # comment = passive subject
-1	Hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1782,7 +1782,7 @@
 # text = His was cleaned.
 # previous = What happened to Alex's car?
 # comment = passive subject
-1	His	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	His	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1791,7 +1791,7 @@
 # text = Theirs was cleaned.
 # previous = What happened to Alex's car?
 # comment = passive subject
-1	Theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1800,7 +1800,7 @@
 # text = Mine was cleaned.
 # previous = What happened to your car?
 # comment = passive subject
-1	Mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1809,7 +1809,7 @@
 # text = Yours was cleaned.
 # previous = What happened to my car?
 # comment = passive subject
-1	Yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -1821,7 +1821,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	drove	drive	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 6	responsively	responsive	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	6	punct	_	_
@@ -1833,7 +1833,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	drove	drive	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 6	responsively	responsive	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	6	punct	_	_
@@ -1845,7 +1845,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	drove	drive	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 6	responsively	responsive	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	6	punct	_	_
@@ -1857,7 +1857,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	drove	drive	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	_
 6	responsively	responsive	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	6	punct	_	_
@@ -1869,7 +1869,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	drove	drive	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	_
 6	responsively	responsive	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	6	punct	_	_
@@ -1884,7 +1884,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	of	of	ADP	IN	_	7	case	_	_
-7	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
+7	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 177
@@ -1897,7 +1897,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	of	of	ADP	IN	_	7	case	_	_
-7	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
+7	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 178
@@ -1910,7 +1910,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	of	of	ADP	IN	_	7	case	_	_
-7	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
+7	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 179
@@ -1923,7 +1923,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	of	of	ADP	IN	_	7	case	_	_
-7	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
+7	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 180
@@ -1936,7 +1936,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	of	of	ADP	IN	_	7	case	_	_
-7	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
+7	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 181
@@ -1946,7 +1946,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	7	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 7	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
@@ -1959,7 +1959,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	7	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 7	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
@@ -1972,7 +1972,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	7	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 7	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
@@ -1985,7 +1985,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	7	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 7	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
@@ -1998,7 +1998,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	7	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 7	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
@@ -2010,7 +2010,7 @@
 # comment = "of" genitive and partitive in subject of passive sentence
 1	One	one	NUM	N	NumType=Card	5	nsubj	_	_
 2	of	of	ADP	IN	_	3	case	_	_
-3	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
+3	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
 4	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
@@ -2021,7 +2021,7 @@
 # comment = "of" genitive and partitive in subject of passive sentence
 1	One	one	NUM	N	NumType=Card	5	nsubj	_	_
 2	of	of	ADP	IN	_	3	case	_	_
-3	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
+3	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
 4	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
@@ -2032,7 +2032,7 @@
 # comment = "of" genitive and partitive in subject of passive sentence
 1	One	one	NUM	N	NumType=Card	5	nsubj	_	_
 2	of	of	ADP	IN	_	3	case	_	_
-3	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
+3	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
 4	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
@@ -2043,7 +2043,7 @@
 # comment = "of" genitive and partitive in subject of passive sentence
 1	One	one	NUM	N	NumType=Card	5	nsubj	_	_
 2	of	of	ADP	IN	_	3	case	_	_
-3	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	1	nmod	_	_
+3	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	1	nmod	_	_
 4	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
@@ -2054,7 +2054,7 @@
 # comment = "of" genitive and partitive in subject of passive sentence
 1	One	one	NUM	N	NumType=Card	5	nsubj	_	_
 2	of	of	ADP	IN	_	3	case	_	_
-3	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	1	nmod	_	_
+3	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	1	nmod	_	_
 4	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	5	punct	_	_
@@ -2066,7 +2066,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 6	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	6	punct	_	_
@@ -2078,7 +2078,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 6	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	6	punct	_	_
@@ -2090,7 +2090,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 6	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	6	punct	_	_
@@ -2102,7 +2102,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 6	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	6	punct	_	_
@@ -2114,7 +2114,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 6	cleaned	clean	VERB	V	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	Period	_	6	punct	_	_
@@ -2123,7 +2123,7 @@
 # text = Hers, the dealer cleaned.
 # previous = What did the dealer do with Alex's car?
 # comment = extracted/raised object
-1	Hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
+1	Hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	5	nsubj	_	_
@@ -2134,7 +2134,7 @@
 # text = His, the dealer cleaned.
 # previous = What did the dealer do with Alex's car?
 # comment = extracted/raised object
-1	His	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
+1	His	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	5	nsubj	_	_
@@ -2145,7 +2145,7 @@
 # text = Theirs, the dealer cleaned.
 # previous = What did the dealer do with Alex's car?
 # comment = extracted/raised object
-1	Theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
+1	Theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	5	nsubj	_	_
@@ -2156,7 +2156,7 @@
 # text = Mine, the dealer cleaned.
 # previous = What did the dealer do with your car?
 # comment = extracted/raised object
-1	Mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
+1	Mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	5	nsubj	_	_
@@ -2167,7 +2167,7 @@
 # text = Yours, the dealer cleaned.
 # previous = What did the dealer do with my car?
 # comment = extracted/raised object
-1	Yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
+1	Yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	5	nsubj	_	_
@@ -2184,7 +2184,7 @@
 4	cars	car	NOUN	_	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
-7	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
+7	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 202
@@ -2197,7 +2197,7 @@
 4	cars	car	NOUN	_	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
-7	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
+7	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 203
@@ -2210,7 +2210,7 @@
 4	cars	car	NOUN	_	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
-7	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
+7	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 204
@@ -2223,7 +2223,7 @@
 4	cars	car	NOUN	_	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
-7	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
+7	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 205
@@ -2236,7 +2236,7 @@
 4	cars	car	NOUN	_	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
-7	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
+7	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	2	punct	_	_
 
 # sent_id = 206
@@ -2248,7 +2248,7 @@
 3	seeing	see	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
 4	cars	car	NOUN	_	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
-6	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
+6	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
 7	especially	especially	ADV	RB	_	6	orphan	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -2261,7 +2261,7 @@
 3	seeing	see	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
 4	cars	car	NOUN	_	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
-6	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
+6	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
 7	especially	especially	ADV	RB	_	6	orphan	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -2274,7 +2274,7 @@
 3	seeing	see	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
 4	cars	car	NOUN	_	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
-6	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
+6	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
 7	especially	especially	ADV	RB	_	6	orphan	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -2287,7 +2287,7 @@
 3	seeing	see	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
 4	cars	car	NOUN	_	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
-6	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	conj	_	_
+6	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	conj	_	_
 7	especially	especially	ADV	RB	_	6	orphan	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -2300,7 +2300,7 @@
 3	seeing	see	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Inf	2	xcomp	_	_
 4	cars	car	NOUN	_	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
-6	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	conj	_	_
+6	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	conj	_	_
 7	especially	especially	ADV	RB	_	6	orphan	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -2316,7 +2316,7 @@
 6	:	:	PUNCT	:	_	3	punct	_	_
 7	it	it	PRON	PERS-SG	_	9	nsubj	_	_
 8	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-9	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
+9	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
 10	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 212
@@ -2331,7 +2331,7 @@
 6	:	:	PUNCT	:	_	3	punct	_	_
 7	it	it	PRON	PERS-SG	_	9	nsubj	_	_
 8	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-9	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
+9	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
 10	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 213
@@ -2346,7 +2346,7 @@
 6	:	:	PUNCT	:	_	3	punct	_	_
 7	it	it	PRON	PERS-SG	_	9	nsubj	_	_
 8	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-9	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
+9	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
 10	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 214
@@ -2361,7 +2361,7 @@
 6	:	:	PUNCT	:	_	3	punct	_	_
 7	it	it	PRON	PERS-SG	_	9	nsubj	_	_
 8	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-9	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
+9	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
 10	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 215
@@ -2376,14 +2376,14 @@
 6	:	:	PUNCT	:	_	3	punct	_	_
 7	it	it	PRON	PERS-SG	_	9	nsubj	_	_
 8	was	be	AUX	VA	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-9	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
+9	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
 10	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 216
 # text = Hers'll do.
 # previous = Which person's car do we want?
 # comment = with auxiliary suffix
-1	Hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
+1	Hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	'll	will	AUX	MD	VerbForm=Fin	3	aux	_	_
 3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -2392,7 +2392,7 @@
 # text = His'll do.
 # previous = Which person's car do we want?
 # comment = with auxiliary suffix
-1	His	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
+1	His	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	'll	will	AUX	MD	VerbForm=Fin	3	aux	_	_
 3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -2401,7 +2401,7 @@
 # text = Theirs'll do.
 # previous = Which person's car do we want?
 # comment = with auxiliary suffix
-1	Theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
+1	Theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	'll	will	AUX	MD	VerbForm=Fin	3	aux	_	_
 3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -2410,7 +2410,7 @@
 # text = Mine'll do.
 # previous = Which person's car do we want?
 # comment = with auxiliary suffix
-1	Mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
+1	Mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	'll	will	AUX	MD	VerbForm=Fin	3	aux	_	_
 3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -2419,7 +2419,7 @@
 # text = Yours'll do.
 # previous = Which person's car do we want?
 # comment = with auxiliary suffix
-1	Yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
+1	Yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	'll	will	AUX	MD	VerbForm=Fin	3	aux	_	_
 3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	Period	_	3	punct	_	_
@@ -2434,7 +2434,7 @@
 4	fresh	fresh	ADJ	A	_	5	amod	_	_
 5	paint	paint	NOUN	NN	Number=Sing	3	obj	_	_
 6	to	to	ADP	E	_	7	case	_	_
-7	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 222
@@ -2447,7 +2447,7 @@
 4	fresh	fresh	ADJ	A	_	5	amod	_	_
 5	paint	paint	NOUN	NN	Number=Sing	3	obj	_	_
 6	to	to	ADP	E	_	7	case	_	_
-7	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 223
@@ -2460,7 +2460,7 @@
 4	fresh	fresh	ADJ	A	_	5	amod	_	_
 5	paint	paint	NOUN	NN	Number=Sing	3	obj	_	_
 6	to	to	ADP	E	_	7	case	_	_
-7	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 224
@@ -2473,7 +2473,7 @@
 4	fresh	fresh	ADJ	A	_	5	amod	_	_
 5	paint	paint	NOUN	NN	Number=Sing	3	obj	_	_
 6	to	to	ADP	E	_	7	case	_	_
-7	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 225
@@ -2486,7 +2486,7 @@
 4	fresh	fresh	ADJ	A	_	5	amod	_	_
 5	paint	paint	NOUN	NN	Number=Sing	3	obj	_	_
 6	to	to	ADP	E	_	7	case	_	_
-7	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 226
@@ -2497,7 +2497,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	walked	walk	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	to	to	ADP	E	_	3	case	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 227
@@ -2508,7 +2508,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	walked	walk	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	to	to	ADP	E	_	3	case	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 228
@@ -2519,7 +2519,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	walked	walk	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	to	to	ADP	E	_	3	case	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 229
@@ -2530,7 +2530,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	walked	walk	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	to	to	ADP	E	_	3	case	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 230
@@ -2541,7 +2541,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	walked	walk	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	to	to	ADP	E	_	3	case	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 231
@@ -2552,7 +2552,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	drove	drive	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	using	use	VERB	V	VerbForm=Ger	3	advcl	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 232
@@ -2563,7 +2563,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	drove	drive	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	using	use	VERB	V	VerbForm=Ger	3	advcl	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 233
@@ -2574,7 +2574,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	drove	drive	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	using	use	VERB	V	VerbForm=Ger	3	advcl	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 234
@@ -2585,7 +2585,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	drove	drive	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	using	use	VERB	V	VerbForm=Ger	3	advcl	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 235
@@ -2596,7 +2596,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	drove	drive	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	using	use	VERB	V	VerbForm=Ger	3	advcl	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 236
@@ -2607,7 +2607,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	went	go	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	with	with	ADP	E	_	3	case	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 237
@@ -2618,7 +2618,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	went	go	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	with	with	ADP	E	_	3	case	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 238
@@ -2629,7 +2629,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	went	go	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	with	with	ADP	E	_	3	case	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 239
@@ -2640,7 +2640,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	went	go	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	with	with	ADP	E	_	3	case	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 240
@@ -2651,7 +2651,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	went	go	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	with	with	ADP	E	_	3	case	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 241
@@ -2662,7 +2662,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	waited	wait	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	E	_	3	case	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 242
@@ -2673,7 +2673,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	waited	wait	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	E	_	3	case	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 243
@@ -2684,7 +2684,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	waited	wait	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	E	_	3	case	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 244
@@ -2695,7 +2695,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	waited	wait	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	E	_	3	case	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 245
@@ -2706,7 +2706,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	waited	wait	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	E	_	3	case	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 246
@@ -2717,7 +2717,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	got	get	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	into	into	ADP	E	_	3	case	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 247
@@ -2728,7 +2728,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	got	get	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	into	into	ADP	E	_	3	case	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 248
@@ -2739,7 +2739,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	got	get	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	into	into	ADP	E	_	3	case	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 249
@@ -2750,7 +2750,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	got	get	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	into	into	ADP	E	_	3	case	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 250
@@ -2761,7 +2761,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	got	get	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	into	into	ADP	E	_	3	case	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 251
@@ -2772,7 +2772,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	came	come	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	from	from	ADP	E	_	3	case	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 252
@@ -2783,7 +2783,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	came	come	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	from	from	ADP	E	_	3	case	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 253
@@ -2794,7 +2794,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	came	come	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	from	from	ADP	E	_	3	case	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 254
@@ -2805,7 +2805,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	came	come	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	from	from	ADP	E	_	3	case	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 255
@@ -2816,7 +2816,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	came	come	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	from	from	ADP	E	_	3	case	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 256
@@ -2827,7 +2827,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	sat	sit	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	on	on	ADP	E	_	3	case	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 257
@@ -2838,7 +2838,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	sat	sit	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	on	on	ADP	E	_	3	case	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 258
@@ -2849,7 +2849,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	sat	sit	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	on	on	ADP	E	_	3	case	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 259
@@ -2860,7 +2860,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	sat	sit	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	on	on	ADP	E	_	3	case	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 260
@@ -2871,7 +2871,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	sat	sit	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	on	on	ADP	E	_	3	case	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	Period	_	3	punct	_	_
 
 # sent_id = 261
@@ -2882,7 +2882,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	recommended	recommend	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	get	get	VERB	V	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	painted	paint	ADJ	POS	Degree=Pos	6	xcomp	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -2895,7 +2895,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	recommended	recommend	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	get	get	VERB	V	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	painted	paint	ADJ	POS	Degree=Pos	6	xcomp	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -2908,7 +2908,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	recommended	recommend	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	get	get	VERB	V	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	painted	paint	ADJ	POS	Degree=Pos	6	xcomp	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -2921,7 +2921,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	recommended	recommend	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	get	get	VERB	V	Mood=Sub|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	painted	paint	ADJ	POS	Degree=Pos	6	xcomp	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -2934,7 +2934,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	recommended	recommend	VERB	V	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	_	_	6	mark	_	_
-5	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	get	get	VERB	V	Mood=Sub|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	painted	paint	ADJ	POS	Degree=Pos	6	xcomp	_	SpaceAfter=No
 8	.	.	PUNCT	Period	_	3	punct	_	_
@@ -2944,7 +2944,7 @@
 # previous = Which should I take?
 # comment = imperative
 1	Take	take	VERB	V	Mood=Imp|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
+2	hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	1	punct	_	_
 
 # sent_id = 267
@@ -2952,7 +2952,7 @@
 # previous = Which should I take?
 # comment = imperative
 1	Take	take	VERB	V	Mood=Imp|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	his	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
+2	his	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	1	punct	_	_
 
 # sent_id = 268
@@ -2960,7 +2960,7 @@
 # previous = Which should I take?
 # comment = imperative
 1	Take	take	VERB	V	Mood=Imp|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
+2	theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	1	punct	_	_
 
 # sent_id = 269
@@ -2968,7 +2968,7 @@
 # previous = Which should I take?
 # comment = imperative
 1	Take	take	VERB	V	Mood=Imp|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
+2	mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	1	punct	_	_
 
 # sent_id = 270
@@ -2976,14 +2976,14 @@
 # previous = Which should I take?
 # comment = imperative
 1	Take	take	VERB	V	Mood=Imp|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
+2	yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	1	punct	_	_
 
 # sent_id = 271
 # text = Hers is easy to clean.
 # previous = What did the dealer like about Alex's car?
 # comment = extraction/raising via "tough extraction" and clausal subject
-1	Hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	3	cop	_	_
 3	easy	easy	ADJ	JJ	Degree=Pos	0	root	_	_
 4	to	to	PART	TO	_	5	mark	_	_
@@ -2994,7 +2994,7 @@
 # text = His is easy to clean.
 # previous = What did the dealer like about Alex's car?
 # comment = extraction/raising via "tough extraction" and clausal subject
-1	His	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	His	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	3	cop	_	_
 3	easy	easy	ADJ	JJ	Degree=Pos	0	root	_	_
 4	to	to	PART	TO	_	5	mark	_	_
@@ -3005,7 +3005,7 @@
 # text = Theirs is easy to clean.
 # previous = What did the dealer like about Alex's car?
 # comment = extraction/raising via "tough extraction" and clausal subject
-1	Theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Inf	3	cop	_	_
 3	easy	easy	ADJ	JJ	Degree=Pos	0	root	_	_
 4	to	to	PART	TO	_	5	mark	_	_
@@ -3016,7 +3016,7 @@
 # text = Mine is easy to clean.
 # previous = What did the dealer like about your car?
 # comment = extraction/raising via "tough extraction" and clausal subject
-1	Mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Inf	3	cop	_	_
 3	easy	easy	ADJ	JJ	Degree=Pos	0	root	_	_
 4	to	to	PART	TO	_	5	mark	_	_
@@ -3027,7 +3027,7 @@
 # text = Yours is easy to clean.
 # previous = What did the dealer like about my car?
 # comment = extraction/raising via "tough extraction" and clausal subject
-1	Yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Inf	3	cop	_	_
 3	easy	easy	ADJ	JJ	Degree=Pos	0	root	_	_
 4	to	to	PART	TO	_	5	mark	_	_
@@ -3038,7 +3038,7 @@
 # text = Hers parks.
 # previous = What does Alex's car do?
 # comment = subject of unaccusative intransitive
-1	Hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	parks	park	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -3046,7 +3046,7 @@
 # text = His parks.
 # previous = What does Alex's car do?
 # comment = subject of unaccusative intransitive
-1	His	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	His	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	parks	park	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -3054,7 +3054,7 @@
 # text = Theirs parks.
 # previous = What does Alex's car do?
 # comment = subject of unaccusative intransitive
-1	Theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	parks	park	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -3062,7 +3062,7 @@
 # text = Mine parks.
 # previous = What does your car do?
 # comment = subject of unaccusative intransitive
-1	Mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	parks	park	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -3070,7 +3070,7 @@
 # text = Yours parks.
 # previous = What does my car do?
 # comment = subject of unaccusative intransitive
-1	Yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	parks	park	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -3078,7 +3078,7 @@
 # text = Hers broke.
 # previous = What was Alex's car like?
 # comment = subject of unergative intransitive
-1	Hers	she	PRON	SG-GEN-INDEP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Hers	she	PRON	SG-GEN-INDEP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	broke	break	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -3086,7 +3086,7 @@
 # text = His broke.
 # previous = What was Alex's car like?
 # comment = subject of unergative intransitive
-1	His	he	PRON	SG-GEN-INDEP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	His	he	PRON	SG-GEN-INDEP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	broke	break	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -3094,7 +3094,7 @@
 # text = Theirs broke.
 # previous = What was Alex's car like?
 # comment = subject of unergative intransitive
-1	Theirs	they	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Theirs	they	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	broke	break	VERB	V	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -3102,7 +3102,7 @@
 # text = Mine broke.
 # previous = What was your car like?
 # comment = subject of unergative intransitive
-1	Mine	me	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Mine	me	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	broke	break	VERB	V	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 
@@ -3110,7 +3110,7 @@
 # text = Yours broke.
 # previous = What was my car like?
 # comment = subject of unergative intransitive
-1	Yours	you	PRON	SG-GEN-INDEP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Yours	you	PRON	SG-GEN-INDEP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	broke	break	VERB	V	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	Period	_	2	punct	_	_
 

--- a/en_pronouns-ud-test.conllu
+++ b/en_pronouns-ud-test.conllu
@@ -314,7 +314,6 @@
 4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
-
 # sent_id = 34
 # text = it aint mine.
 # previous = Does this belong to Alex?
@@ -678,7 +677,7 @@
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 68
-# text = The car aint their.s
+# text = The car aint theirs.
 # previous = Does the car belong to Alex?
 # comment = copular object with informal negation
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_

--- a/en_pronouns-ud-test.conllu
+++ b/en_pronouns-ud-test.conllu
@@ -5,7 +5,7 @@
 # comment = copular subject
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 2
@@ -14,7 +14,7 @@
 # comment = copular subject
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 3
@@ -23,7 +23,7 @@
 # comment = copular subject
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 4
@@ -32,7 +32,7 @@
 # comment = copular subject
 1	It	it	PRON	PRP	Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 5
@@ -41,7 +41,7 @@
 # comment = copular subject
 1	It	it	PRON	PRP	Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 6
@@ -50,7 +50,7 @@
 # comment = abbreviated copular subject
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 7
@@ -59,7 +59,7 @@
 # comment = abbreviated copular subject
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 8
@@ -68,7 +68,7 @@
 # comment = abbreviated copular subject
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 9
@@ -77,7 +77,7 @@
 # comment = abbreviated copular subject
 1	It	it	PRON	PRP	Number=Sing|Person=1|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 10
@@ -86,7 +86,7 @@
 # comment = abbreviated copular subject
 1	It	it	PRON	PRP	Number=Sing|Person=2|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+3	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 11
@@ -96,7 +96,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	all	all	DET	DT	Case=Nom	4	det:predet	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 12
@@ -106,7 +106,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	all	all	DET	DT	Case=Nom	4	det:predet	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 13
@@ -116,7 +116,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	all	all	DET	DT	Case=Nom	4	det:predet	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 14
@@ -126,7 +126,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=1|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	all	all	DET	DT	Case=Nom	4	det:predet	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 15
@@ -136,7 +136,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=2|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	all	all	DET	DT	Case=Nom	4	det:predet	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 16
@@ -146,7 +146,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	mostly	mostly	ADV	RB	_	4	advmod	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 17
@@ -156,7 +156,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	mostly	mostly	ADV	RB	_	4	advmod	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 18
@@ -166,7 +166,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	mostly	mostly	ADV	RB	_	4	advmod	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 19
@@ -176,7 +176,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=1|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	mostly	mostly	ADV	RB	_	4	advmod	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 20
@@ -186,7 +186,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=2|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	mostly	mostly	ADV	RB	_	4	advmod	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 21
@@ -195,7 +195,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	not	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 22
@@ -204,7 +204,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	not	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 23
@@ -213,7 +213,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	not	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 24
@@ -222,7 +222,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=1|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	not	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 25
@@ -231,7 +231,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=2|PronType=Prs	4	nsubj	_	SpaceAfter=No
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
 3	not	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 26
@@ -241,7 +241,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	n't	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 27
@@ -251,7 +251,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	n't	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 28
@@ -261,7 +261,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	n't	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 29
@@ -271,7 +271,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	n't	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 30
@@ -281,7 +281,7 @@
 1	It	it	PRON	PRP	Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	n't	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 31
@@ -291,7 +291,7 @@
 1	it	it	PRON	VBZ	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	ai	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	nt	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 32
@@ -301,7 +301,7 @@
 1	it	it	PRON	VBZ	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	ai	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	nt	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 33
@@ -311,7 +311,7 @@
 1	it	it	PRON	VBZ	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	ai	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	nt	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 34
@@ -321,7 +321,7 @@
 1	it	it	PRON	VBZ	Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
 2	ai	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	nt	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 35
@@ -331,7 +331,7 @@
 1	it	it	PRON	VBZ	Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
 2	ai	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	_	SpaceAfter=No
 3	nt	not	PART	RB	Polarity=Neg	4	advmod	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 36
@@ -341,7 +341,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 37
@@ -351,7 +351,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 38
@@ -361,7 +361,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 39
@@ -371,7 +371,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 40
@@ -381,7 +381,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 41
@@ -391,7 +391,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 42
@@ -401,7 +401,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 43
@@ -411,7 +411,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 44
@@ -421,7 +421,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 45
@@ -431,7 +431,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	4	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 46
@@ -442,7 +442,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	all	all	DET	DT	Case=Nom	5	nmod	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 47
@@ -453,7 +453,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	all	all	DET	DT	Case=Nom	5	nmod	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 48
@@ -464,7 +464,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	all	all	DET	DT	Case=Nom	5	nmod	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 49
@@ -475,7 +475,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	all	all	DET	DT	Case=Nom	5	nmod	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 50
@@ -486,7 +486,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	all	all	DET	DT	Case=Nom	5	nmod	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 51
@@ -497,7 +497,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	mostly	mostly	ADV	RB	_	5	advmod	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 52
@@ -508,7 +508,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	mostly	mostly	ADV	RB	_	5	advmod	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 53
@@ -519,7 +519,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	mostly	mostly	ADV	RB	_	5	advmod	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 54
@@ -530,7 +530,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	mostly	mostly	ADV	RB	_	5	advmod	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 55
@@ -541,7 +541,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	mostly	mostly	ADV	RB	_	5	advmod	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 56
@@ -552,7 +552,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	not	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 57
@@ -563,7 +563,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	not	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 58
@@ -574,7 +574,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	not	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 59
@@ -585,7 +585,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	not	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 60
@@ -596,7 +596,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	SpaceAfter=No
 3	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	not	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 61
@@ -607,7 +607,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	n't	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 62
@@ -618,7 +618,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	n't	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 63
@@ -629,7 +629,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	n't	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 64
@@ -640,7 +640,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	n't	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 65
@@ -651,7 +651,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	n't	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 66
@@ -662,7 +662,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	ai	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	nt	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 67
@@ -673,7 +673,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	ai	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	nt	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 68
@@ -684,7 +684,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	ai	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	nt	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 69
@@ -695,7 +695,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	ai	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	nt	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 70
@@ -706,7 +706,7 @@
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	ai	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	_	SpaceAfter=No
 4	nt	not	PART	RB	Polarity=Neg	5	advmod	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 71
@@ -716,7 +716,7 @@
 1	Any	any	DET	DT	PronType=Ind	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	sells	sell	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	quickly	quickly	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	5	punct	_	_
@@ -728,7 +728,7 @@
 1	Any	any	DET	DT	PronType=Ind	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	sells	sell	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	quickly	quickly	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	5	punct	_	_
@@ -740,7 +740,7 @@
 1	Any	any	DET	DT	PronType=Ind	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	sells	sell	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	quickly	quickly	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	5	punct	_	_
@@ -752,7 +752,7 @@
 1	Any	any	DET	DT	PronType=Ind	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	sells	sell	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	quickly	quickly	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	5	punct	_	_
@@ -764,7 +764,7 @@
 1	Any	any	DET	DT	PronType=Ind	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	sells	sell	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 6	quickly	quickly	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	5	punct	_	_
@@ -775,7 +775,7 @@
 # comment = expositional subject
 1	There	there	PRON	EX	_	2	expl	_	_
 2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
+3	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 77
@@ -784,7 +784,7 @@
 # comment = expositional subject
 1	There	there	PRON	EX	_	2	expl	_	_
 2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
+3	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 78
@@ -793,7 +793,7 @@
 # comment = expositional subject
 1	There	there	PRON	EX	_	2	expl	_	_
 2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
+3	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 79
@@ -802,7 +802,7 @@
 # comment = expositional subject
 1	There	there	PRON	EX	_	2	expl	_	_
 2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
+3	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 80
@@ -811,7 +811,7 @@
 # comment = expositional subject
 1	There	there	PRON	EX	_	2	expl	_	_
 2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
+3	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 81
@@ -822,7 +822,7 @@
 2	car	car	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	IN	_	5	case	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 82
@@ -833,7 +833,7 @@
 2	car	car	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	IN	_	5	case	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 83
@@ -844,7 +844,7 @@
 2	car	car	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	IN	_	5	case	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 84
@@ -855,7 +855,7 @@
 2	car	car	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	IN	_	5	case	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 85
@@ -866,14 +866,14 @@
 2	car	car	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	IN	_	5	case	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	xcomp	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 86
 # text = Hers is nice.
 # previous = What do you think of Alex's car?
 # comment = copular subject with adjective
-1	Hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	nice	nice	ADJ	JJ	_	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -882,7 +882,7 @@
 # text = His is nice.
 # previous = What do you think of Alex's car?
 # comment = copular subject with adjective
-1	His	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	His	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	nice	nice	ADJ	JJ	_	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -891,7 +891,7 @@
 # text = Theirs is nice.
 # previous = What do you think of Alex's car?
 # comment = copular subject with adjective
-1	Theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	nice	nice	ADJ	JJ	_	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -900,7 +900,7 @@
 # text = Mine is nice.
 # previous = What do you think of your car?
 # comment = copular subject with adjective
-1	Mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	nice	nice	ADJ	JJ	_	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -909,7 +909,7 @@
 # text = Yours is nice.
 # previous = What do you think of my car?
 # comment = copular subject with adjective
-1	Yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	nice	nice	ADJ	JJ	_	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -918,7 +918,7 @@
 # text = Hers drove responsively.
 # previous = How did Alex's car drive?
 # comment = subject to irregular intransitive verb
-1	Hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	responsively	responsively	ADV	RB	_	2	advmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
@@ -927,7 +927,7 @@
 # text = His drove responsively.
 # previous = How did Alex's car drive?
 # comment = subject to irregular intransitive verb
-1	His	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	His	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	responsively	responsively	ADV	RB	_	2	advmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
@@ -936,7 +936,7 @@
 # text = Theirs drove responsively.
 # previous = How did Alex's car drive?
 # comment = subject to irregular intransitive verb
-1	Theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	responsively	responsively	ADV	RB	_	2	advmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
@@ -945,7 +945,7 @@
 # text = Mine drove responsively.
 # previous = How did your car drive?
 # comment = subject to irregular intransitive verb
-1	Mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	_
 3	responsively	responsively	ADV	RB	_	2	advmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
@@ -954,7 +954,7 @@
 # text = Yours drove responsively.
 # previous = How did my car drive?
 # comment = subject to irregular intransitive verb
-1	Yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	_
 3	responsively	responsively	ADV	RB	_	2	advmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
@@ -963,7 +963,7 @@
 # text = Hers accelerated.
 # comment = subject to regular intransitive verb
 # previous = What did Alex's car do?
-1	Hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	accelerated	accelerate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -971,7 +971,7 @@
 # text = His accelerated.
 # comment = subject to regular intransitive verb
 # previous = What did Alex's car do?
-1	His	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	His	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	accelerated	accelerate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -979,7 +979,7 @@
 # text = Theirs accelerated.
 # comment = subject to regular intransitive verb
 # previous = What did Alex's car do?
-1	Theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	accelerated	accelerate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -987,7 +987,7 @@
 # text = Mine accelerated.
 # comment = subject to regular intransitive verb
 # previous = What did your car do?
-1	Mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	accelerated	accelerate	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -995,7 +995,7 @@
 # text = Yours accelerated.
 # comment = subject to regular intransitive verb
 # previous = What did my car do?
-1	Yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	accelerated	accelerate	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1003,7 +1003,7 @@
 # text = Hers hit bumps.
 # previous = What did Alex's car hit?
 # comment = subject to regular transitive verb
-1	Hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	hit	hit	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	bumps	bump	NOUN	NNS	Number=Plur	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
@@ -1012,7 +1012,7 @@
 # text = His hit bumps.
 # previous = What did Alex's car hit?
 # comment = subject to regular transitive verb
-1	His	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	His	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	hit	hit	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	bumps	bump	NOUN	NNS	Number=Plur	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
@@ -1021,7 +1021,7 @@
 # text = Theirs hit bumps.
 # previous = What did Alex's car hit?
 # comment = subject to regular transitive verb
-1	Theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	hit	hit	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 3	bumps	bump	NOUN	NNS	Number=Plur	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
@@ -1030,7 +1030,7 @@
 # text = Mine hit bumps.
 # previous = What did your car hit?
 # comment = subject to regular transitive verb
-1	Mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	hit	hit	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	_
 3	bumps	bump	NOUN	NNS	Number=Plur	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
@@ -1039,7 +1039,7 @@
 # text = Yours hit bumps.
 # previous = What did my car hit?
 # comment = subject to regular transitive verb
-1	Yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	hit	hit	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	_
 3	bumps	bump	NOUN	NNS	Number=Plur	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
@@ -1051,7 +1051,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
 5	fresh	fresh	ADJ	JJ	_	6	amod	_	_
 6	paint	paint	NOUN	NN	Number=Sing	3	obj	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	3	punct	_	_
@@ -1063,7 +1063,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
 5	fresh	fresh	ADJ	JJ	_	6	amod	_	_
 6	paint	paint	NOUN	NN	Number=Sing	3	obj	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	3	punct	_	_
@@ -1075,7 +1075,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	iobj	_	_
 5	fresh	fresh	ADJ	JJ	_	6	amod	_	_
 6	paint	paint	NOUN	NN	Number=Sing	3	obj	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	3	punct	_	_
@@ -1087,7 +1087,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	iobj	_	_
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	iobj	_	_
 5	fresh	fresh	ADJ	JJ	_	6	amod	_	_
 6	paint	paint	NOUN	NN	Number=Sing	3	obj	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	3	punct	_	_
@@ -1099,7 +1099,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	iobj	_	_
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	iobj	_	_
 5	fresh	fresh	ADJ	JJ	_	6	amod	_	_
 6	paint	paint	NOUN	NN	Number=Sing	3	obj	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	3	punct	_	_
@@ -1110,7 +1110,7 @@
 # comment = direct object to irregular transitive verb (accusative, absolutive) 
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	saw	see	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
+3	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 112
@@ -1119,7 +1119,7 @@
 # comment = direct object to irregular transitive verb (accusative, absolutive) 
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	saw	see	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
+3	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 113
@@ -1128,7 +1128,7 @@
 # comment = direct object to irregular transitive verb (accusative, absolutive) 
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	saw	see	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
+3	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 114
@@ -1137,7 +1137,7 @@
 # comment = direct object to irregular transitive verb (accusative, absolutive) 
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	saw	see	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	_
-3	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
+3	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 115
@@ -1146,7 +1146,7 @@
 # comment = direct object to irregular transitive verb (accusative, absolutive) 
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	saw	see	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	_
-3	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
+3	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 116
@@ -1157,7 +1157,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easily	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1170,7 +1170,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easily	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1183,7 +1183,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easily	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1196,7 +1196,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easily	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1209,7 +1209,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easily	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1222,7 +1222,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1235,7 +1235,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1248,7 +1248,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1261,7 +1261,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1274,7 +1274,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	liked	like	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1287,7 +1287,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easily	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1300,7 +1300,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easily	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1313,7 +1313,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easily	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1326,7 +1326,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easily	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1339,7 +1339,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	cleaned	clean	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	easily	easily	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1352,7 +1352,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1365,7 +1365,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1378,7 +1378,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1391,7 +1391,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1404,7 +1404,7 @@
 2	dealers	dealer	NOUN	NNS	Number=Plur	3	nsubj	_	_
 3	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	sold	sell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	_	_
 7	quickly	quickly	ADV	RB	_	6	advmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -1416,7 +1416,7 @@
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 137
@@ -1426,7 +1426,7 @@
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 138
@@ -1436,7 +1436,7 @@
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 139
@@ -1446,7 +1446,7 @@
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 140
@@ -1456,7 +1456,7 @@
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 141
@@ -1466,7 +1466,7 @@
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	cleaning	clean	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 142
@@ -1476,7 +1476,7 @@
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	cleaning	clean	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 143
@@ -1486,7 +1486,7 @@
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	cleaning	clean	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 144
@@ -1496,7 +1496,7 @@
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	cleaning	clean	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 145
@@ -1506,7 +1506,7 @@
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	cleaning	clean	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 146
@@ -1518,7 +1518,7 @@
 3	's	's	PART	POS	_	2	case	_	_
 4	cars	car	NOUN	NNS	Number=Plur	7	nsubj	_	_
 5	and	and	CCONJ	CC	_	6	cc	_	_
-6	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
+6	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
 7	sell	sell	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	quickly	quickly	ADV	RB	_	7	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	7	punct	_	_
@@ -1532,7 +1532,7 @@
 3	's	's	PART	POS	_	2	case	_	_
 4	cars	car	NOUN	NNS	Number=Plur	7	nsubj	_	_
 5	and	and	CCONJ	CC	_	6	cc	_	_
-6	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
+6	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
 7	sell	sell	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	quickly	quickly	ADV	RB	_	7	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	7	punct	_	_
@@ -1546,7 +1546,7 @@
 3	's	's	PART	POS	_	2	case	_	_
 4	cars	car	NOUN	NNS	Number=Plur	7	nsubj	_	_
 5	and	and	CCONJ	CC	_	6	cc	_	_
-6	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
+6	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	conj	_	_
 7	sell	sell	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	quickly	quickly	ADV	RB	_	7	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	7	punct	_	_
@@ -1560,7 +1560,7 @@
 3	's	's	PART	POS	_	2	case	_	_
 4	cars	car	NOUN	NNS	Number=Plur	7	nsubj	_	_
 5	and	and	CCONJ	CC	_	6	cc	_	_
-6	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	4	conj	_	_
+6	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	4	conj	_	_
 7	sell	sell	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	quickly	quickly	ADV	RB	_	7	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	7	punct	_	_
@@ -1574,7 +1574,7 @@
 3	's	's	PART	POS	_	2	case	_	_
 4	cars	car	NOUN	NNS	Number=Plur	7	nsubj	_	_
 5	and	and	CCONJ	CC	_	6	cc	_	_
-6	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	4	conj	_	_
+6	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	4	conj	_	_
 7	sell	sell	VERB	VBP	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
 8	quickly	quickly	ADV	RB	_	7	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	7	punct	_	_
@@ -1583,7 +1583,7 @@
 # text = Hers and the dealer's sold quickly.
 # previous = Did the dealer's cars and Alex's sell quickly?
 # comment = head part of conjunction
-1	Hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+1	Hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 2	and	and	CCONJ	CC	_	4	cc	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	1	conj	_	SpaceAfter=No
@@ -1596,7 +1596,7 @@
 # text = His and the dealer's sold quickly.
 # previous = Did the dealer's cars and Alex's sell quickly?
 # comment = head part of conjunction
-1	His	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+1	His	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 2	and	and	CCONJ	CC	_	4	cc	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	1	conj	_	SpaceAfter=No
@@ -1609,7 +1609,7 @@
 # text = Theirs and the dealer's sold quickly.
 # previous = Did the dealer's cars and Alex's sell quickly?
 # comment = head part of conjunction
-1	Theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+1	Theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 2	and	and	CCONJ	CC	_	4	cc	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	1	conj	_	SpaceAfter=No
@@ -1622,7 +1622,7 @@
 # text = Mine and the dealer's sold quickly.
 # previous = Did the dealer's cars and your sell quickly?
 # comment = head part of conjunction
-1	Mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+1	Mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 2	and	and	CCONJ	CC	_	4	cc	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	1	conj	_	SpaceAfter=No
@@ -1635,7 +1635,7 @@
 # text = Yours and the dealer's sold quickly.
 # previous = Did the dealer's cars and my sell quickly?
 # comment = head part of conjunction
-1	Yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+1	Yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 2	and	and	CCONJ	CC	_	4	cc	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	1	conj	_	SpaceAfter=No
@@ -1654,7 +1654,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	before	before	ADP	IN	_	7	case	_	_
-7	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 157
@@ -1667,7 +1667,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	before	before	ADP	IN	_	7	case	_	_
-7	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 158
@@ -1680,7 +1680,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	before	before	ADP	IN	_	7	case	_	_
-7	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 159
@@ -1693,7 +1693,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	before	before	ADP	IN	_	7	case	_	_
-7	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 160
@@ -1706,7 +1706,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	before	before	ADP	IN	_	7	case	_	_
-7	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 161
@@ -1714,7 +1714,7 @@
 # previous = Did the dealer clean their car before Alex's car?
 # comment = complement after clause
 1	After	after	ADP	IN	_	2	case	_	_
-2	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
+2	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	6	punct	_	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	dealer	dealer	NOUN	NN	Number=Sing	6	nsubj	_	_
@@ -1728,7 +1728,7 @@
 # previous = Did the dealer clean their car before Alex's car?
 # comment = complement after clause
 1	After	after	ADP	IN	_	2	case	_	_
-2	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
+2	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	6	punct	_	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	dealer	dealer	NOUN	NN	Number=Sing	6	nsubj	_	_
@@ -1742,7 +1742,7 @@
 # previous = Did the dealer clean their car before Alex's car?
 # comment = complement after clause
 1	After	after	ADP	IN	_	2	case	_	_
-2	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
+2	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	6	punct	_	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	dealer	dealer	NOUN	NN	Number=Sing	6	nsubj	_	_
@@ -1756,7 +1756,7 @@
 # previous = Did the dealer clean their car before your car?
 # comment = complement after clause
 1	After	after	ADP	IN	_	2	case	_	_
-2	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
+2	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	6	punct	_	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	dealer	dealer	NOUN	NN	Number=Sing	6	nsubj	_	_
@@ -1770,7 +1770,7 @@
 # previous = Did the dealer clean their car before my car?
 # comment = complement after clause
 1	After	after	ADP	IN	_	2	case	_	_
-2	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
+2	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	obl	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	6	punct	_	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	dealer	dealer	NOUN	NN	Number=Sing	6	nsubj	_	_
@@ -1783,7 +1783,7 @@
 # text = Hers was cleaned.
 # previous = What happened to Alex's car?
 # comment = passive subject
-1	Hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -1792,7 +1792,7 @@
 # text = His was cleaned.
 # previous = What happened to Alex's car?
 # comment = passive subject
-1	His	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	His	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -1801,7 +1801,7 @@
 # text = Theirs was cleaned.
 # previous = What happened to Alex's car?
 # comment = passive subject
-1	Theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -1810,7 +1810,7 @@
 # text = Mine was cleaned.
 # previous = What happened to your car?
 # comment = passive subject
-1	Mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -1819,7 +1819,7 @@
 # text = Yours was cleaned.
 # previous = What happened to my car?
 # comment = passive subject
-1	Yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -1831,7 +1831,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 6	responsively	responsively	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	_	_
@@ -1843,7 +1843,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 6	responsively	responsively	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	_	_
@@ -1855,7 +1855,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 6	responsively	responsively	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	_	_
@@ -1867,7 +1867,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	_
 6	responsively	responsively	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	_	_
@@ -1879,7 +1879,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	5	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	_
 6	responsively	responsively	ADV	RB	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	_	_
@@ -1894,7 +1894,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	of	of	ADP	IN	_	7	case	_	_
-7	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
+7	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 177
@@ -1907,7 +1907,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	of	of	ADP	IN	_	7	case	_	_
-7	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
+7	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 178
@@ -1920,7 +1920,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	of	of	ADP	IN	_	7	case	_	_
-7	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
+7	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 179
@@ -1933,7 +1933,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	of	of	ADP	IN	_	7	case	_	_
-7	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
+7	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 180
@@ -1946,7 +1946,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	_	_
 5	car	car	NOUN	NN	Number=Sing	3	obj	_	_
 6	of	of	ADP	IN	_	7	case	_	_
-7	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
+7	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 181
@@ -1956,7 +1956,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	7	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 7	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
@@ -1969,7 +1969,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	7	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 7	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
@@ -1982,7 +1982,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	7	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 7	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
@@ -1995,7 +1995,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	7	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 7	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
@@ -2008,7 +2008,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	7	nsubj	_	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	appos	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux:pass	_	_
 7	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
@@ -2020,7 +2020,7 @@
 # comment = "of" genitive and partitive in subject of passive sentence
 1	One	one	NUM	CD	NumType=Card	5	nsubj	_	_
 2	of	of	ADP	IN	_	3	case	_	_
-3	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
+3	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
 4	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
@@ -2031,7 +2031,7 @@
 # comment = "of" genitive and partitive in subject of passive sentence
 1	One	one	NUM	CD	NumType=Card	5	nsubj	_	_
 2	of	of	ADP	IN	_	3	case	_	_
-3	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
+3	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
 4	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
@@ -2042,7 +2042,7 @@
 # comment = "of" genitive and partitive in subject of passive sentence
 1	One	one	NUM	CD	NumType=Card	5	nsubj	_	_
 2	of	of	ADP	IN	_	3	case	_	_
-3	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
+3	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nmod	_	_
 4	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
@@ -2053,7 +2053,7 @@
 # comment = "of" genitive and partitive in subject of passive sentence
 1	One	one	NUM	CD	NumType=Card	5	nsubj	_	_
 2	of	of	ADP	IN	_	3	case	_	_
-3	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	1	nmod	_	_
+3	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	1	nmod	_	_
 4	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
@@ -2064,7 +2064,7 @@
 # comment = "of" genitive and partitive in subject of passive sentence
 1	One	one	NUM	CD	NumType=Card	5	nsubj	_	_
 2	of	of	ADP	IN	_	3	case	_	_
-3	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	1	nmod	_	_
+3	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	1	nmod	_	_
 4	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	_	_
@@ -2076,7 +2076,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 6	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	_	_
@@ -2088,7 +2088,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 6	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	_	_
@@ -2100,7 +2100,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 6	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	_	_
@@ -2112,7 +2112,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 6	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	_	_
@@ -2124,7 +2124,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	_	_
 2	car	car	NOUN	NN	Number=Sing	6	nsubj	_	_
 3	of	of	ADP	IN	_	4	case	_	_
-4	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
+4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nmod	_	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	_	_
 6	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	_	_
@@ -2133,7 +2133,7 @@
 # text = Hers, the dealer cleaned.
 # previous = What did the dealer do with Alex's car?
 # comment = extracted/raised object
-1	Hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
+1	Hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	5	nsubj	_	_
@@ -2144,7 +2144,7 @@
 # text = His, the dealer cleaned.
 # previous = What did the dealer do with Alex's car?
 # comment = extracted/raised object
-1	His	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
+1	His	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	5	nsubj	_	_
@@ -2155,7 +2155,7 @@
 # text = Theirs, the dealer cleaned.
 # previous = What did the dealer do with Alex's car?
 # comment = extracted/raised object
-1	Theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
+1	Theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	5	nsubj	_	_
@@ -2166,7 +2166,7 @@
 # text = Mine, the dealer cleaned.
 # previous = What did the dealer do with your car?
 # comment = extracted/raised object
-1	Mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
+1	Mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	5	nsubj	_	_
@@ -2177,7 +2177,7 @@
 # text = Yours, the dealer cleaned.
 # previous = What did the dealer do with my car?
 # comment = extracted/raised object
-1	Yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
+1	Yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	5	obl	_	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	_	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	_	_
 4	dealer	dealer	NOUN	NN	Number=Sing	5	nsubj	_	_
@@ -2194,7 +2194,7 @@
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
-7	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
+7	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 202
@@ -2207,7 +2207,7 @@
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
-7	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
+7	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 203
@@ -2220,7 +2220,7 @@
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
-7	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
+7	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 204
@@ -2233,7 +2233,7 @@
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
-7	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
+7	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 205
@@ -2246,7 +2246,7 @@
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
-7	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
+7	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	conj	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 206
@@ -2258,7 +2258,7 @@
 3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
-6	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
+6	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
 7	especially	especially	ADV	RB	_	6	orphan	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -2271,7 +2271,7 @@
 3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
-6	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
+6	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
 7	especially	especially	ADV	RB	_	6	orphan	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -2284,7 +2284,7 @@
 3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
-6	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
+6	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
 7	especially	especially	ADV	RB	_	6	orphan	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -2297,7 +2297,7 @@
 3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
-6	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	conj	_	_
+6	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	conj	_	_
 7	especially	especially	ADV	RB	_	6	orphan	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -2310,7 +2310,7 @@
 3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
-6	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	conj	_	_
+6	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	conj	_	_
 7	especially	especially	ADV	RB	_	6	orphan	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -2326,7 +2326,7 @@
 6	:	:	PUNCT	:	_	3	punct	_	_
 7	it	it	PRON	VBZ	_	9	nsubj	_	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-9	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
+9	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 212
@@ -2341,7 +2341,7 @@
 6	:	:	PUNCT	:	_	3	punct	_	_
 7	it	it	PRON	VBZ	_	9	nsubj	_	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-9	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
+9	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 213
@@ -2356,7 +2356,7 @@
 6	:	:	PUNCT	:	_	3	punct	_	_
 7	it	it	PRON	VBZ	_	9	nsubj	_	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-9	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
+9	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 214
@@ -2371,7 +2371,7 @@
 6	:	:	PUNCT	:	_	3	punct	_	_
 7	it	it	PRON	VBZ	_	9	nsubj	_	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-9	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
+9	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 215
@@ -2386,14 +2386,14 @@
 6	:	:	PUNCT	:	_	3	punct	_	_
 7	it	it	PRON	VBZ	_	9	nsubj	_	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux:pass	_	_
-9	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
+9	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	parataxis	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 216
 # text = Hers'll do.
 # previous = Which person's car do we want?
 # comment = with auxiliary suffix
-1	Hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
+1	Hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	'll	will	AUX	MD	VerbForm=Fin	3	aux	_	_
 3	do	do	VERB	VB	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -2402,7 +2402,7 @@
 # text = His'll do.
 # previous = Which person's car do we want?
 # comment = with auxiliary suffix
-1	His	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
+1	His	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	'll	will	AUX	MD	VerbForm=Fin	3	aux	_	_
 3	do	do	VERB	VB	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -2411,7 +2411,7 @@
 # text = Theirs'll do.
 # previous = Which person's car do we want?
 # comment = with auxiliary suffix
-1	Theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
+1	Theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	'll	will	AUX	MD	VerbForm=Fin	3	aux	_	_
 3	do	do	VERB	VB	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -2420,7 +2420,7 @@
 # text = Mine'll do.
 # previous = Which person's car do we want?
 # comment = with auxiliary suffix
-1	Mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
+1	Mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	'll	will	AUX	MD	VerbForm=Fin	3	aux	_	_
 3	do	do	VERB	VB	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -2429,7 +2429,7 @@
 # text = Yours'll do.
 # previous = Which person's car do we want?
 # comment = with auxiliary suffix
-1	Yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
+1	Yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	SpaceAfter=No
 2	'll	will	AUX	MD	VerbForm=Fin	3	aux	_	_
 3	do	do	VERB	VB	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	_	_
@@ -2444,7 +2444,7 @@
 4	fresh	fresh	ADJ	JJ	_	5	amod	_	_
 5	paint	paint	NOUN	NN	Number=Sing	3	obj	_	_
 6	to	to	ADP	IN	_	7	case	_	_
-7	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 222
@@ -2457,7 +2457,7 @@
 4	fresh	fresh	ADJ	JJ	_	5	amod	_	_
 5	paint	paint	NOUN	NN	Number=Sing	3	obj	_	_
 6	to	to	ADP	IN	_	7	case	_	_
-7	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 223
@@ -2470,7 +2470,7 @@
 4	fresh	fresh	ADJ	JJ	_	5	amod	_	_
 5	paint	paint	NOUN	NN	Number=Sing	3	obj	_	_
 6	to	to	ADP	IN	_	7	case	_	_
-7	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 224
@@ -2483,7 +2483,7 @@
 4	fresh	fresh	ADJ	JJ	_	5	amod	_	_
 5	paint	paint	NOUN	NN	Number=Sing	3	obj	_	_
 6	to	to	ADP	IN	_	7	case	_	_
-7	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 225
@@ -2496,7 +2496,7 @@
 4	fresh	fresh	ADJ	JJ	_	5	amod	_	_
 5	paint	paint	NOUN	NN	Number=Sing	3	obj	_	_
 6	to	to	ADP	IN	_	7	case	_	_
-7	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+7	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 226
@@ -2507,7 +2507,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	to	to	ADP	IN	_	3	case	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 227
@@ -2518,7 +2518,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	to	to	ADP	IN	_	3	case	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 228
@@ -2529,7 +2529,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	to	to	ADP	IN	_	3	case	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 229
@@ -2540,7 +2540,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	to	to	ADP	IN	_	3	case	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 230
@@ -2551,7 +2551,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	to	to	ADP	IN	_	3	case	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 231
@@ -2562,7 +2562,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	drove	drive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	using	use	VERB	VBG	VerbForm=Ger	3	advcl	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 232
@@ -2573,7 +2573,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	drove	drive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	using	use	VERB	VBG	VerbForm=Ger	3	advcl	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 233
@@ -2584,7 +2584,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	drove	drive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	using	use	VERB	VBG	VerbForm=Ger	3	advcl	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 234
@@ -2595,7 +2595,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	drove	drive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	using	use	VERB	VBG	VerbForm=Ger	3	advcl	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 235
@@ -2606,7 +2606,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	drove	drive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	using	use	VERB	VBG	VerbForm=Ger	3	advcl	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 236
@@ -2617,7 +2617,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	with	with	ADP	IN	_	3	case	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 237
@@ -2628,7 +2628,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	with	with	ADP	IN	_	3	case	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 238
@@ -2639,7 +2639,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	with	with	ADP	IN	_	3	case	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 239
@@ -2650,7 +2650,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	with	with	ADP	IN	_	3	case	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 240
@@ -2661,7 +2661,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	with	with	ADP	IN	_	3	case	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 241
@@ -2672,7 +2672,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	waited	wait	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	IN	_	3	case	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 242
@@ -2683,7 +2683,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	waited	wait	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	IN	_	3	case	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 243
@@ -2694,7 +2694,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	waited	wait	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	IN	_	3	case	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 244
@@ -2705,7 +2705,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	waited	wait	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	IN	_	3	case	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 245
@@ -2716,7 +2716,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	waited	wait	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	at	at	ADP	IN	_	3	case	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 246
@@ -2727,7 +2727,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	into	into	ADP	IN	_	3	case	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 247
@@ -2738,7 +2738,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	into	into	ADP	IN	_	3	case	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 248
@@ -2749,7 +2749,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	into	into	ADP	IN	_	3	case	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 249
@@ -2760,7 +2760,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	into	into	ADP	IN	_	3	case	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 250
@@ -2771,7 +2771,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	into	into	ADP	IN	_	3	case	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 251
@@ -2782,7 +2782,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	from	from	ADP	IN	_	3	case	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 252
@@ -2793,7 +2793,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	from	from	ADP	IN	_	3	case	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 253
@@ -2804,7 +2804,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	from	from	ADP	IN	_	3	case	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 254
@@ -2815,7 +2815,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	from	from	ADP	IN	_	3	case	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 255
@@ -2826,7 +2826,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	from	from	ADP	IN	_	3	case	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 256
@@ -2837,7 +2837,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	sat	sit	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	on	on	ADP	IN	_	3	case	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 257
@@ -2848,7 +2848,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	sat	sit	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	on	on	ADP	IN	_	3	case	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 258
@@ -2859,7 +2859,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	sat	sit	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	on	on	ADP	IN	_	3	case	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 259
@@ -2870,7 +2870,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	sat	sit	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	on	on	ADP	IN	_	3	case	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 260
@@ -2881,7 +2881,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	sat	sit	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	on	on	ADP	IN	_	3	case	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 261
@@ -2892,7 +2892,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	recommended	recommend	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	get	get	VERB	VBP	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	painted	paint	VERB	VBN	Tense=Past|VerbForm=Part	6	xcomp	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -2905,7 +2905,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	recommended	recommend	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	get	get	VERB	VBP	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	painted	paint	VERB	VBN	Tense=Past|VerbForm=Part	6	xcomp	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -2918,7 +2918,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	recommended	recommend	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	get	get	VERB	VBP	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	painted	paint	VERB	VBN	Tense=Past|VerbForm=Part	6	xcomp	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -2931,7 +2931,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	recommended	recommend	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	get	get	VERB	VBP	Mood=Sub|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	painted	paint	VERB	VBN	Tense=Past|VerbForm=Part	6	xcomp	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -2944,7 +2944,7 @@
 2	dealer	dealer	NOUN	NN	Number=Sing	3	nsubj	_	_
 3	recommended	recommend	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	_
 4	that	that	SCONJ	IN	_	6	mark	_	_
-5	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
+5	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	6	nsubj	_	_
 6	get	get	VERB	VBP	Mood=Sub|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
 7	painted	paint	VERB	VBN	Tense=Past|VerbForm=Part	6	xcomp	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -2954,7 +2954,7 @@
 # previous = Which should I take?
 # comment = imperative
 1	Take	take	VERB	VB	Mood=Imp|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
+2	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 267
@@ -2962,7 +2962,7 @@
 # previous = Which should I take?
 # comment = imperative
 1	Take	take	VERB	VB	Mood=Imp|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	his	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
+2	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 268
@@ -2970,7 +2970,7 @@
 # previous = Which should I take?
 # comment = imperative
 1	Take	take	VERB	VB	Mood=Imp|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
+2	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 269
@@ -2978,7 +2978,7 @@
 # previous = Which should I take?
 # comment = imperative
 1	Take	take	VERB	VB	Mood=Imp|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
+2	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 270
@@ -2986,14 +2986,14 @@
 # previous = Which should I take?
 # comment = imperative
 1	Take	take	VERB	VB	Mood=Imp|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
+2	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	1	nsubj	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 271
 # text = Hers is easy to clean.
 # previous = What did the dealer like about Alex's car?
 # comment = extraction/raising via "tough extraction" and clausal subject
-1	Hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	easy	easy	ADJ	JJ	Degree=Pos	0	root	_	_
 4	to	to	PART	TO	_	5	mark	_	_
@@ -3004,7 +3004,7 @@
 # text = His is easy to clean.
 # previous = What did the dealer like about Alex's car?
 # comment = extraction/raising via "tough extraction" and clausal subject
-1	His	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	His	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	easy	easy	ADJ	JJ	Degree=Pos	0	root	_	_
 4	to	to	PART	TO	_	5	mark	_	_
@@ -3015,7 +3015,7 @@
 # text = Theirs is easy to clean.
 # previous = What did the dealer like about Alex's car?
 # comment = extraction/raising via "tough extraction" and clausal subject
-1	Theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	easy	easy	ADJ	JJ	Degree=Pos	0	root	_	_
 4	to	to	PART	TO	_	5	mark	_	_
@@ -3026,7 +3026,7 @@
 # text = Mine is easy to clean.
 # previous = What did the dealer like about your car?
 # comment = extraction/raising via "tough extraction" and clausal subject
-1	Mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	easy	easy	ADJ	JJ	Degree=Pos	0	root	_	_
 4	to	to	PART	TO	_	5	mark	_	_
@@ -3037,7 +3037,7 @@
 # text = Yours is easy to clean.
 # previous = What did the dealer like about my car?
 # comment = extraction/raising via "tough extraction" and clausal subject
-1	Yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
+1	Yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	nsubj	_	_
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	easy	easy	ADJ	JJ	Degree=Pos	0	root	_	_
 4	to	to	PART	TO	_	5	mark	_	_
@@ -3048,7 +3048,7 @@
 # text = Hers parks.
 # previous = What does Alex's car do?
 # comment = subject of unaccusative intransitive
-1	Hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	parks	park	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3056,7 +3056,7 @@
 # text = His parks.
 # previous = What does Alex's car do?
 # comment = subject of unaccusative intransitive
-1	His	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	His	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	parks	park	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3064,7 +3064,7 @@
 # text = Theirs parks.
 # previous = What does Alex's car do?
 # comment = subject of unaccusative intransitive
-1	Theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	parks	park	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3072,7 +3072,7 @@
 # text = Mine parks.
 # previous = What does your car do?
 # comment = subject of unaccusative intransitive
-1	Mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	parks	park	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3080,7 +3080,7 @@
 # text = Yours parks.
 # previous = What does my car do?
 # comment = subject of unaccusative intransitive
-1	Yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	parks	park	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3088,7 +3088,7 @@
 # text = Hers broke.
 # previous = What was Alex's car like?
 # comment = subject of unergative intransitive
-1	Hers	hers	PRON	PRP	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	broke	break	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3096,7 +3096,7 @@
 # text = His broke.
 # previous = What was Alex's car like?
 # comment = subject of unergative intransitive
-1	His	his	PRON	PRP	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	His	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	broke	break	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3104,7 +3104,7 @@
 # text = Theirs broke.
 # previous = What was Alex's car like?
 # comment = subject of unergative intransitive
-1	Theirs	theirs	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	broke	break	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3112,7 +3112,7 @@
 # text = Mine broke.
 # previous = What was your car like?
 # comment = subject of unergative intransitive
-1	Mine	mine	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	broke	break	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3120,7 +3120,7 @@
 # text = Yours broke.
 # previous = What was my car like?
 # comment = subject of unergative intransitive
-1	Yours	yours	PRON	PRP	Case=Gen|Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
+1	Yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	nsubj	_	_
 2	broke	break	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 

--- a/en_pronouns-ud-test.conllu
+++ b/en_pronouns-ud-test.conllu
@@ -1415,7 +1415,7 @@
 # comment = direct object of irregular infinitive verb (see) in complement of regular verb (like)
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1425,7 +1425,7 @@
 # comment = direct object of irregular infinitive verb (see) in complement of regular verb (like)
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1435,7 +1435,7 @@
 # comment = direct object of irregular infinitive verb (see) in complement of regular verb (like)
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1445,7 +1445,7 @@
 # comment = direct object of irregular infinitive verb (see) in complement of regular verb (like)
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1455,7 +1455,7 @@
 # comment = direct object of irregular infinitive verb (see) in complement of regular verb (like)
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1465,7 +1465,7 @@
 # comment = direct object of regular infinitive verb (clean) in complement of regular verb (like)
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	cleaning	clean	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	cleaning	clean	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1475,7 +1475,7 @@
 # comment = direct object of regular infinitive verb (clean) in complement of regular verb (like)
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	cleaning	clean	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	cleaning	clean	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1485,7 +1485,7 @@
 # comment = direct object of regular infinitive verb (clean) in complement of regular verb (like)
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	cleaning	clean	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	cleaning	clean	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1495,7 +1495,7 @@
 # comment = direct object of regular infinitive verb (clean) in complement of regular verb (like)
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	cleaning	clean	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	cleaning	clean	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1505,7 +1505,7 @@
 # comment = direct object of regular infinitive verb (clean) in complement of regular verb (like)
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	cleaning	clean	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	cleaning	clean	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	3	obj	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -2190,7 +2190,7 @@
 # comment = with orphaned dependent preceding due to verb ellipsis in conjunction
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
@@ -2203,7 +2203,7 @@
 # comment = with orphaned dependent preceding due to verb ellipsis in conjunction
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
@@ -2216,7 +2216,7 @@
 # comment = with orphaned dependent preceding due to verb ellipsis in conjunction
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
@@ -2229,7 +2229,7 @@
 # comment = with orphaned dependent preceding due to verb ellipsis in conjunction
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
@@ -2242,7 +2242,7 @@
 # comment = with orphaned dependent preceding due to verb ellipsis in conjunction
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	especially	especially	ADV	RB	_	7	orphan	_	_
@@ -2255,7 +2255,7 @@
 # comment = with orphaned following dependent due to verb ellipsis in conjunction
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	hers	hers	PRON	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
@@ -2268,7 +2268,7 @@
 # comment = with orphaned following dependent due to verb ellipsis in conjunction
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	his	his	PRON	PRP	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
@@ -2281,7 +2281,7 @@
 # comment = with orphaned following dependent due to verb ellipsis in conjunction
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	theirs	theirs	PRON	PRP	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	conj	_	_
@@ -2294,7 +2294,7 @@
 # comment = with orphaned following dependent due to verb ellipsis in conjunction
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	mine	mine	PRON	PRP	Gender=Neut|Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	conj	_	_
@@ -2307,7 +2307,7 @@
 # comment = with orphaned following dependent due to verb ellipsis in conjunction
 1	Dealers	dealer	NOUN	NNS	Number=Plur	2	nsubj	_	_
 2	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	seeing	see	VERB	VBG	Mood=Part|Tense=Pres	2	xcomp	_	_
+3	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	2	xcomp	_	_
 4	cars	car	NOUN	NNS	Number=Plur	3	obj	_	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	_	_
 6	yours	yours	PRON	PRP	Gender=Neut|Number=Sing|Person=2|Poss=Yes|PronType=Prs	2	conj	_	_

--- a/stats.xml
+++ b/stats.xml
@@ -30,8 +30,7 @@
     <tag name="VERB">255</tag><!-- clean, like, sell, see, drive, be, get, give, know, accelerate -->
   </tags>
   <!-- Statistics of features and values. The comments show the most frequent word forms. -->
-  <feats unique="27">
-    <feat name="Case" value="Gen" upos="PRON">285</feat><!-- hers, his, mine, theirs, yours -->
+  <feats unique="26">
     <feat name="Case" value="Nom" upos="PRON">10</feat><!-- all -->
     <feat name="Definite" value="Def" upos="DET">180</feat><!-- the -->
     <feat name="Degree" value="Pos" upos="ADJ">10</feat><!-- easy, painted -->

--- a/stats.xml
+++ b/stats.xml
@@ -5,58 +5,59 @@
        fused is the number of tokens that are split to two or more syntactic words
        The words and fused elements can be omitted if no token is split to smaller syntactic words. -->
   <size>
-    <total><sentences>285</sentences><tokens>1695</tokens><words>1695</words><fused>0</fused></total>
+    <total><sentences>285</sentences><tokens>1705</tokens><words>1705</words><fused>0</fused></total>
     <train><sentences>0</sentences><tokens>0</tokens><words>0</words><fused>0</fused></train>
     <dev><sentences>0</sentences><tokens>0</tokens><words>0</words><fused>0</fused></dev>
-    <test><sentences>285</sentences><tokens>1695</tokens><words>1695</words><fused>0</fused></test>
+    <test><sentences>285</sentences><tokens>1705</tokens><words>1705</words><fused>0</fused></test>
   </size>
-  <lemmas unique="62" /><!-- ., the, dealer, be, car, clean, he, me, she, they, you, it, ,, like, not -->
+  <lemmas unique="63" /><!-- ., the, dealer, be, car, clean, hers, his, mine, theirs, yours, it, ,, like, not -->
   <forms unique="77" /><!-- ., the, dealer, car, hers, his, mine, theirs, yours, cleaned, 's, dealers, is, it, , -->
   <fusions unique="0" /><!--  -->
   <!-- Statistics of universal POS tags. The comments show the most frequent lemmas. -->
   <tags unique="13">
-    <tag name="ADJ">25</tag><!-- fresh, easy, paint, quick -->
+    <tag name="ADJ">20</tag><!-- fresh, easy, nice -->
     <tag name="ADP">75</tag><!-- of, at, to, after, before, from, into, on, with -->
-    <tag name="ADV">65</tag><!-- quickly, easy, especially, most, responsive -->
-    <tag name="AUX">115</tag><!-- be, do, will -->
+    <tag name="ADV">65</tag><!-- quickly, easily, especially, mostly, responsively -->
+    <tag name="AUX">110</tag><!-- be, will -->
     <tag name="CCONJ">10</tag><!-- and -->
-    <tag name="DET">185</tag><!-- the, any -->
+    <tag name="DET">195</tag><!-- the, all, any -->
     <tag name="NOUN">240</tag><!-- dealer, car, paint, bump -->
     <tag name="NUM">5</tag><!-- one -->
     <tag name="PART">45</tag><!-- not, 's, to -->
-    <tag name="PRON">340</tag><!-- he, me, she, they, you, it, all, there -->
-    <tag name="PUNCT">310</tag><!-- ., ,, !, : -->
+    <tag name="PRON">330</tag><!-- hers, his, mine, theirs, yours, it, there -->
+    <tag name="PUNCT">320</tag><!-- ., ,, !, : -->
     <tag name="SCONJ">25</tag><!-- that -->
-    <tag name="VERB">255</tag><!-- clean, like, sell, see, drive, be, get, give, know, accelerate -->
+    <tag name="VERB">265</tag><!-- clean, like, sell, see, drive, be, get, give, know, accelerate -->
   </tags>
   <!-- Statistics of features and values. The comments show the most frequent word forms. -->
-  <feats unique="26">
-    <feat name="Case" value="Nom" upos="PRON">10</feat><!-- all -->
+  <feats unique="27">
+    <feat name="Case" value="Nom" upos="DET">10</feat><!-- all -->
     <feat name="Definite" value="Def" upos="DET">180</feat><!-- the -->
-    <feat name="Degree" value="Pos" upos="ADJ">10</feat><!-- easy, painted -->
+    <feat name="Degree" value="Pos" upos="ADJ">5</feat><!-- easy -->
     <feat name="Gender" value="Fem" upos="PRON">57</feat><!-- hers -->
     <feat name="Gender" value="Masc" upos="PRON">57</feat><!-- his -->
     <feat name="Gender" value="Neut" upos="PRON">171</feat><!-- mine, theirs, yours -->
     <feat name="Mood" value="Imp" upos="VERB">5</feat><!-- Take -->
-    <feat name="Mood" value="Ind" upos="AUX,VERB">330</feat><!-- 's, is, cleaned, was, like, drove, seeing, sold, ai, gave -->
+    <feat name="Mood" value="Ind" upos="AUX,VERB">305</feat><!-- 's, is, cleaned, was, like, drove, sold, ai, gave, knew -->
+    <feat name="Mood" value="Part" upos="VERB">20</feat><!-- seeing, cleaning -->
     <feat name="Mood" value="Sub" upos="VERB">5</feat><!-- get -->
-    <feat name="Number" value="Plur" upos="AUX,NOUN">70</feat><!-- dealers, cars, bumps, is -->
-    <feat name="Number" value="Sing" upos="AUX,NOUN,PRON,VERB">750</feat><!-- dealer, car, hers, his, mine, theirs, yours, 's, cleaned, is -->
+    <feat name="Number" value="Plur" upos="NOUN,VERB">95</feat><!-- dealers, like, cars, bumps, sell, sold -->
+    <feat name="Number" value="Sing" upos="AUX,NOUN,PRON,VERB">700</feat><!-- dealer, car, hers, his, mine, theirs, yours, 's, is, cleaned -->
     <feat name="NumType" value="Card" upos="NUM">5</feat><!-- One -->
-    <feat name="Person" value="1" upos="AUX,PRON,VERB">114</feat><!-- mine, 's, cleaned, it, is, was, like, seeing, sold, ai -->
-    <feat name="Person" value="2" upos="AUX,PRON,VERB">114</feat><!-- yours, 's, cleaned, it, is, was, like, seeing, sold, ai -->
-    <feat name="Person" value="3" upos="AUX,PRON,VERB">342</feat><!-- hers, his, theirs, 's, cleaned, it, is, was, like, seeing -->
+    <feat name="Person" value="1" upos="AUX,PRON,VERB">92</feat><!-- mine, cleaned, it, was, like, ai, drove, sold, accelerated, broke -->
+    <feat name="Person" value="2" upos="AUX,PRON,VERB">87</feat><!-- yours, cleaned, it, like, ai, drove, sold, accelerated, broke, get -->
+    <feat name="Person" value="3" upos="AUX,PRON,VERB">366</feat><!-- hers, his, theirs, 's, is, cleaned, it, was, like, sold -->
     <feat name="Polarity" value="Neg" upos="PART">30</feat><!-- n't, not, nt -->
     <feat name="Poss" value="Yes" upos="PRON">285</feat><!-- hers, his, mine, theirs, yours -->
     <feat name="PronType" value="Art" upos="DET">180</feat><!-- the -->
     <feat name="PronType" value="Ind" upos="DET">5</feat><!-- Any -->
     <feat name="PronType" value="Prs" upos="PRON">320</feat><!-- hers, his, mine, theirs, yours, it -->
-    <feat name="Tense" value="Past" upos="AUX,VERB">185</feat><!-- cleaned, was, drove, gave, knew, liked, accelerated, broke, came, got -->
-    <feat name="Tense" value="Pres" upos="AUX,VERB">175</feat><!-- 's, is, like, seeing, ai, sold, Take, clean, cleaning, do -->
-    <feat name="VerbForm" value="Fin" upos="AUX,VERB">320</feat><!-- 's, cleaned, is, was, like, drove, sold, ai, gave, knew -->
+    <feat name="Tense" value="Past" upos="AUX,VERB">200</feat><!-- cleaned, was, drove, sold, gave, knew, liked, accelerated, broke, came -->
+    <feat name="Tense" value="Pres" upos="AUX,VERB">160</feat><!-- 's, is, like, seeing, ai, Take, cleaning, do, get, parks -->
+    <feat name="VerbForm" value="Fin" upos="AUX,VERB">320</feat><!-- 's, is, cleaned, was, like, drove, sold, ai, gave, knew -->
     <feat name="VerbForm" value="Ger" upos="VERB">5</feat><!-- using -->
-    <feat name="VerbForm" value="Inf" upos="AUX,VERB">25</feat><!-- seeing, cleaning, is -->
-    <feat name="VerbForm" value="Part" upos="VERB">20</feat><!-- cleaned -->
+    <feat name="VerbForm" value="Inf" upos="VERB">5</feat><!-- clean -->
+    <feat name="VerbForm" value="Part" upos="VERB">25</feat><!-- cleaned, painted -->
   </feats>
   <!-- Statistics of universal dependency relations. -->
   <deps unique="26">
@@ -83,7 +84,7 @@
     <dep name="obl">55</dep>
     <dep name="orphan">10</dep>
     <dep name="parataxis">5</dep>
-    <dep name="punct">310</dep>
+    <dep name="punct">320</dep>
     <dep name="root">285</dep>
     <dep name="xcomp">30</dep>
   </deps>

--- a/stats.xml
+++ b/stats.xml
@@ -30,7 +30,7 @@
     <tag name="VERB">265</tag><!-- clean, like, sell, see, drive, be, get, give, know, accelerate -->
   </tags>
   <!-- Statistics of features and values. The comments show the most frequent word forms. -->
-  <feats unique="27">
+  <feats unique="26">
     <feat name="Case" value="Nom" upos="DET">10</feat><!-- all -->
     <feat name="Definite" value="Def" upos="DET">180</feat><!-- the -->
     <feat name="Degree" value="Pos" upos="ADJ">5</feat><!-- easy -->
@@ -39,7 +39,6 @@
     <feat name="Gender" value="Neut" upos="PRON">171</feat><!-- mine, theirs, yours -->
     <feat name="Mood" value="Imp" upos="VERB">5</feat><!-- Take -->
     <feat name="Mood" value="Ind" upos="AUX,VERB">305</feat><!-- 's, is, cleaned, was, like, drove, sold, ai, gave, knew -->
-    <feat name="Mood" value="Part" upos="VERB">20</feat><!-- seeing, cleaning -->
     <feat name="Mood" value="Sub" upos="VERB">5</feat><!-- get -->
     <feat name="Number" value="Plur" upos="NOUN,VERB">95</feat><!-- dealers, like, cars, bumps, sell, sold -->
     <feat name="Number" value="Sing" upos="AUX,NOUN,PRON,VERB">700</feat><!-- dealer, car, hers, his, mine, theirs, yours, 's, is, cleaned -->
@@ -57,7 +56,7 @@
     <feat name="VerbForm" value="Fin" upos="AUX,VERB">320</feat><!-- 's, is, cleaned, was, like, drove, sold, ai, gave, knew -->
     <feat name="VerbForm" value="Ger" upos="VERB">5</feat><!-- using -->
     <feat name="VerbForm" value="Inf" upos="VERB">5</feat><!-- clean -->
-    <feat name="VerbForm" value="Part" upos="VERB">25</feat><!-- cleaned, painted -->
+    <feat name="VerbForm" value="Part" upos="VERB">45</feat><!-- cleaned, seeing, cleaning, painted -->
   </feats>
   <!-- Statistics of universal dependency relations. -->
   <deps unique="26">


### PR DESCRIPTION
Removed Case=Gen. This feature is not documented for English and not used in the other English UD treebanks. If it were used with the possessive pronouns, they would have to be lemmatized to the same lemma as the nominative and the accusative forms, i.e., to the corresponding non-possessive pronoun.

Besides, this PR also fixes two low-level validation errors (two empty lines between sentences; typo in the text attribute).